### PR TITLE
🔧 Remove millesconds from datetime in annotations

### DIFF
--- a/src/annotations/parse.rs
+++ b/src/annotations/parse.rs
@@ -40,11 +40,11 @@ mod tests {
     #[test]
     #[serial_test::serial]
     fn test_parse_annotation() {
-        let raw_annotation = "not:{date:'2025-09-29T00:00:43.245684903+02:00',event:'START_WORK',uid:'b86bc6ed-50a5-4ef2-bdd3-e17baef11eff'}";
+        let raw_annotation = "not:{date:'2025-09-29T00:00:43+02:00',event:'START_WORK',uid:'b86bc6ed-50a5-4ef2-bdd3-e17baef11eff'}";
         let annotation = parse_annotation(raw_annotation).unwrap();
         assert_eq!(
             annotation.datetime.to_rfc3339(),
-            "2025-09-29T00:00:43.245684903+02:00"
+            "2025-09-29T00:00:43+02:00"
         );
         assert_eq!(annotation.event, crate::events::models::NotEvent::StartWork);
         assert_eq!(

--- a/src/dates/get.rs
+++ b/src/dates/get.rs
@@ -1,7 +1,8 @@
 use chrono::{Datelike, Local};
 
 pub fn get_now_as_string() -> String {
-    Local::now().to_rfc3339()
+    let now = Local::now();
+    format!("{}{}", now.format("%Y-%m-%dT%H:%M:%S"), now.format("%:z"))
 }
 
 pub fn get_week_of_month() -> u32 {


### PR DESCRIPTION
The date in the annotations has been changed from "2026-04-14T12:44:13.132790946+09:00" to "2026-04-14T12:44:13+09:00".

This new format can be parsed by the current algorithm.