### PR TITLE
💚 Remove useless borrows in formatting macros

### DIFF
--- a/src/commands/new_folder.rs
+++ b/src/commands/new_folder.rs
@@ -15,7 +15,7 @@ pub fn new_folder() -> std::io::Result<String> {
             println!("✅ Folder has been created successfully!");
 
             // create a the config { "created_at": "2025-12-31T23:59:59Z", "type": "day" }
-            let config_file_path = format!("{}{}", &new_folder_path, ".not-config.json");
+            let config_file_path = format!("{}{}", new_folder_path, ".not-config.json");
 
             match File::create(&config_file_path) {
                 Ok(_file) => {
@@ -28,7 +28,7 @@ pub fn new_folder() -> std::io::Result<String> {
             };
 
             // create the default file in the folder
-            let default_file_path = format!("{}{}", &new_folder_path, "not.md");
+            let default_file_path = format!("{}{}", new_folder_path, "not.md");
 
             match File::create(&default_file_path) {
                 Ok(_file) => {

--- a/src/files/create.rs
+++ b/src/files/create.rs
@@ -31,7 +31,7 @@ pub fn create_file(title: Option<String>) -> std::io::Result<String> {
         None => name(),
     };
 
-    let full_not_file_path = format!("{}{}", &not_file_path, not_file_name);
+    let full_not_file_path = format!("{}{}", not_file_path, not_file_name);
 
     // create folders if needed
     if let Err(e) = create_dir_all(&not_file_path) {
@@ -85,14 +85,14 @@ pub fn create_note_file_with_folders(note_type: String) -> std::io::Result<Strin
 
     log::debug!(
         "🚨 Creating note file with folders at path: {}",
-        &today_folder_path
+        today_folder_path
     );
 
     let now: DateTime<Local> = Local::now();
     let today_file_name = get_day_as_string(now);
     let today_file_path = format!(
         "{}{}{}{}{}",
-        &today_folder_path, today_file_name, ".", note_type, ".md"
+        today_folder_path, today_file_name, ".", note_type, ".md"
     );
 
     // only create if not does not already exists
@@ -111,7 +111,7 @@ pub fn create_note_file_with_folders(note_type: String) -> std::io::Result<Strin
 
     log::debug!(
         "🚨 Creating note file with folders at path: {}",
-        &today_file_path
+        today_file_path
     );
 
     // create the file

--- a/src/plugins/gdarquie_work/work.rs
+++ b/src/plugins/gdarquie_work/work.rs
@@ -181,7 +181,7 @@ pub fn compose_monthly_work_stats(stats: MonthlyWorkStats) -> String {
 
             stats_content.push_str(&format!(
                 "| {} | {} | {:.2} | {:.2} |\n",
-                &weekday, &work_stat.day, hours, cumulative_week_hours
+                weekday, work_stat.day, hours, cumulative_week_hours
             ));
         }
     }

--- a/src/projects/initialize.rs
+++ b/src/projects/initialize.rs
@@ -9,7 +9,7 @@ pub fn get_project_config_path() -> String {
         eprintln!("NOT_PATH environment variable not set.");
         std::process::exit(1);
     });
-    format!("{}/{}/", &not_path, ".nost")
+    format!("{}/{}/", not_path, ".nost")
 }
 
 /**
@@ -22,10 +22,10 @@ pub fn is_project_initialized() -> bool {
         std::process::exit(1);
     });
 
-    let project_config_path = format!("{}/.nost/project.json", &not_path,);
+    let project_config_path = format!("{}/.nost/project.json", not_path);
     log::debug!(
         "Checking if configuration exists at path: {}",
-        &project_config_path
+        project_config_path
     );
     Path::new(&project_config_path).is_file()
 }
@@ -54,9 +54,9 @@ pub fn initialize_project() -> Result<String, Box<dyn std::error::Error>> {
     create_dir_all(&configuration_path)?;
 
     // create en empty configuration file
-    let default_config_path = format!("{}{}", &configuration_path, "project.json");
+    let default_config_path = format!("{}{}", configuration_path, "project.json");
     let config_file = std::fs::File::create(&default_config_path)?;
-    log::debug!("Configuration initialized at path: {}", &configuration_path);
+    log::debug!("Configuration initialized at path: {}", configuration_path);
 
     // append inital content to the configuration file
     const NOST_VERSION: &str = env!("CARGO_PKG_VERSION");


### PR DESCRIPTION
Fixes `clippy::useless_borrows_in_formatting` warnings (treated as errors with `-D warnings`) that were breaking the CI.

Removes redundant `&` borrows in `format!`, `debug!` and similar macros across 4 files.