### PR TITLE
🐛 Use today as workday when end_work crosses midnight into a new day

### DIFF
--- a/src/plugins/gdarquie_work/commands/end_work.rs
+++ b/src/plugins/gdarquie_work/commands/end_work.rs
@@ -58,24 +58,29 @@ fn add_stop_work_annotations(last_annotation: &WorkAnnotationWithPath, path: &Pa
                 chrono::Local::now().format("%:z")
             );
 
-            // START_WORK for today
+            // START_WORK for today — use today as workday, not yesterday's
             annotate(
                 Some(&today_datetime_string),
                 EventName::StartWork,
                 None,
                 path.to_str().unwrap(),
-                last_annotation.annotation.workday.as_deref(),
+                Some(today.as_str()),
             );
         }
     }
 
-    // we add a STOP_WORK annotation for today
+    // we add a STOP_WORK annotation for today — use today as workday when crossing midnight
+    let stop_workday = if last_annotation.annotation.workday.as_deref() == Some(&today) {
+        last_annotation.annotation.workday.as_deref()
+    } else {
+        Some(today.as_str())
+    };
     annotate(
         None,
         EventName::StopWork,
         None,
         path.to_str().unwrap(),
-        last_annotation.annotation.workday.as_deref(),
+        stop_workday,
     );
 }
 


### PR DESCRIPTION
## Root cause

When `end_work` is called after midnight (work started yesterday), the "yesterday" branch creates bridge annotations in today's file:
- a `StartWork` at `00:00:00` with `workday = yesterday` ← **wrong**
- a `StopWork` at the current time with `workday = yesterday` ← **wrong**

Because both carry yesterday's workday, they appear in the current month's stats as an extra worked day for yesterday — even though yesterday may belong to the previous month.

## Fix

- `StartWork` bridge at `00:00` now uses **today** as workday.
- Final `StopWork` now uses **today** as workday when crossing midnight.

This ensures that annotations written into today's note file are correctly attributed to today in the stats.

## Relationship to PR #37

PR #37 (`fix/work-stats-extra-day`) fixes the **symptom** by filtering out-of-month workdays from stats. This PR fixes the **root cause** by preventing the wrong workday from being written in the first place. Both are complementary.