### PR TITLE
♻️ Use parse_iso_date for start_work date validation

### DIFF
--- a/src/plugins/gdarquie_work/commands/start_work.rs
+++ b/src/plugins/gdarquie_work/commands/start_work.rs
@@ -1,13 +1,14 @@
 use crate::{
-    annotations::annotate::annotate, events::models::EventName, files::create::create_file,
+    annotations::annotate::annotate, dates::parse::parse_iso_date, events::models::EventName,
+    files::create::create_file,
 };
 
 pub fn start_work(args: Vec<String>) {
     let not_path = create_file(None).unwrap();
     let default_workday;
     let workday = if args.len() > 2 {
-        if chrono::NaiveDate::parse_from_str(&args[2], "%Y-%m-%d").is_err() {
-            eprintln!("Invalid date format. Please use YYYY-MM-DD.");
+        if let Err(msg) = parse_iso_date(&args[2]) {
+            eprintln!("{}", msg);
             std::process::exit(1);
         }
         Some(args[2].as_str())


### PR DESCRIPTION
Converges the `start_work` date validation onto the `parse_iso_date` helper introduced in PR #40.

## Change
- `start_work.rs`: replace the manual `NaiveDate::parse_from_str(...).is_err()` validation with `parse_iso_date`.

## Benefits
- Strict validation (regex + zero-padding) instead of chrono's permissive parse.
- Error message consistent with `new_legacy` (format error).

## Out of scope (intentionally left as-is)
- `work.rs`: the `parse_from_str(...).unwrap()` calls operate on **internal**, already-formatted dates \u2014 trusted data, not a user boundary (the *parse, don't validate* principle applies at the boundary only).

Build clean, 24 tests passing, no regression.