### PR TITLE
🐛 Propagate config load error instead of panicking in get_value_from_config

### DIFF
--- a/src/configurations/get.rs
+++ b/src/configurations/get.rs
@@ -17,8 +17,6 @@ pub fn get_config() -> Result<Config, Box<dyn std::error::Error>> {
  * i.e. get_value_from_config("not_path") will return the value of the "not_path" key in the configuration file.
  */
 pub fn get_value_from_config(key: &str) -> Result<String, Box<dyn std::error::Error>> {
-    let configuration = get_config().unwrap();
-
     if key.is_empty() {
         return Err("Config key cannot be empty".into());
     }
@@ -27,6 +25,8 @@ pub fn get_value_from_config(key: &str) -> Result<String, Box<dyn std::error::Er
     if !configurations_keys.contains(&key) {
         return Err(format!("Key '{}' not found in configuration", key).into());
     }
+
+    let configuration = get_config()?;
 
     match configuration.get_value(key) {
         Some(value) => Ok(value),


### PR DESCRIPTION
## Problem

`get_value_from_config()` returns `Result<String, Box<dyn Error>>`, but internally called `get_config().unwrap()`. If the config file is missing or malformed, the CLI **panics** instead of returning a clean error to the caller — defeating the whole point of the `Result` signature.

## Fix

- Replace `get_config().unwrap()` with `get_config()?` so the underlying error propagates cleanly.
- Reorder: validate the `key` argument (empty / unknown) **before** doing config file I/O — cheaper and more logical (validate input at the boundary before touching the filesystem).

## Testing

`cargo build` + `cargo test` green (24 tests).