### PR TITLE
💚 Fix clippy warnings (needless_borrow, map_entry, bool assert_eq)

### DIFF
--- a/src/files/check_content.rs
+++ b/src/files/check_content.rs
@@ -19,10 +19,10 @@ mod tests {
 
         // Write content with a line break
         fs::write(&file_path, "Hello world!\n").unwrap();
-        assert_eq!(ends_with_line_break(file_path.clone()).unwrap(), true);
+        assert!(ends_with_line_break(file_path.clone()).unwrap());
 
         // Write content without a line break
         fs::write(&file_path, "Hello world!").unwrap();
-        assert_eq!(ends_with_line_break(file_path.clone()).unwrap(), false);
+        assert!(!ends_with_line_break(file_path.clone()).unwrap());
     }
 }

--- a/src/plugins/gdarquie_work/work.rs
+++ b/src/plugins/gdarquie_work/work.rs
@@ -281,30 +281,28 @@ mod tests {
         for (day, annotation) in annotations_hmap.iter() {
             let length_in_minutes = compute_work_time_from_annotations(annotation);
 
-            let date = chrono::NaiveDate::parse_from_str(&day, "%Y-%m-%d").unwrap();
+            let date = chrono::NaiveDate::parse_from_str(day, "%Y-%m-%d").unwrap();
             let week_id = WeekId {
                 year: date.iso_week().year(),
                 week: date.iso_week().week(),
             };
 
-            if work_stats_by_week.contains_key(&week_id) {
+            if let std::collections::hash_map::Entry::Vacant(e) = work_stats_by_week.entry(week_id)
+            {
+                e.insert(WorkStatsByWeek {
+                    total_duration_in_minutes: length_in_minutes,
+                    work_stats: vec![WorkStats {
+                        day: day.clone(),
+                        length_in_minutes,
+                    }],
+                });
+            } else {
                 let week_stats = work_stats_by_week.get_mut(&week_id).unwrap();
                 week_stats.total_duration_in_minutes += length_in_minutes;
                 week_stats.work_stats.push(WorkStats {
                     day: day.clone(),
                     length_in_minutes,
                 });
-            } else {
-                work_stats_by_week.insert(
-                    week_id,
-                    WorkStatsByWeek {
-                        total_duration_in_minutes: length_in_minutes,
-                        work_stats: vec![WorkStats {
-                            day: day.clone(),
-                            length_in_minutes,
-                        }],
-                    },
-                );
             }
 
             total_duration += length_in_minutes;


### PR DESCRIPTION
## What

Auto-applied `cargo clippy --fix` for 4 warnings flagged on `--all-targets`:

- **`needless_borrow`** — expression creating a reference immediately dereferenced (in `work.rs`)
- **`map_entry`** — `contains_key` followed by `insert` on a `HashMap` → use the `entry` API (in `work.rs`)
- **`assert_eq!` with a literal bool** (×2) — replaced with `assert!`/`assert!(!…)` (in `check_content.rs` tests)

Pure lint cleanup, no behavior change.

## Testing

`cargo clippy --all-targets` → **0 warnings**. `cargo test` green (24 tests).