### PR TITLE
♻️ Remove superfluous exit(0) at end of commands

### DIFF
--- a/src/commands/new.rs
+++ b/src/commands/new.rs
@@ -23,8 +23,6 @@ pub fn new_legacy(args: Vec<String>) {
     }
 
     create_file(date).unwrap();
-
-    std::process::exit(0);
 }
 
 pub fn new() {
@@ -33,5 +31,4 @@ pub fn new() {
     let _ = create_note_file_with_folders("default".to_string());
 
     println!("✅ Note has been created successfully!");
-    std::process::exit(0);
 }

--- a/src/plugins/gdarquie_work/commands/end_work.rs
+++ b/src/plugins/gdarquie_work/commands/end_work.rs
@@ -95,10 +95,8 @@ pub fn end_work() {
     if !has_active_session(&last_work_annotation) {
         // return a message, we have nothin to do, there is no active session
         println!("No working active session has been found. No annotation has been added.");
-        std::process::exit(0);
+        return;
     }
 
     add_stop_work_annotations(&last_work_annotation, &path);
-
-    std::process::exit(0);
 }

--- a/src/plugins/gdarquie_work/commands/start_work.rs
+++ b/src/plugins/gdarquie_work/commands/start_work.rs
@@ -17,5 +17,4 @@ pub fn start_work(args: Vec<String>) {
         Some(default_workday.as_str())
     };
     annotate(None, EventName::StartWork, None, &not_path, workday);
-    std::process::exit(0);
 }

--- a/src/plugins/gdarquie_work/commands/work_stats.rs
+++ b/src/plugins/gdarquie_work/commands/work_stats.rs
@@ -40,7 +40,6 @@ pub fn work_stats(args: Vec<String>) {
     } else {
         println!("{}", stats_content);
     }
-    std::process::exit(0);
 }
 
 // Validate a string as year-month in format YYYY-MM (01..12)


### PR DESCRIPTION
## What

Removes `std::process::exit(0)` calls placed at the **end** of command functions, where the function would return naturally anyway:

- `start_work`, `work_stats`, `new_legacy`, `new` — trailing `exit(0)` dropped.
- `end_work` — the early "no active session" `exit(0)` becomes a plain `return`, and the trailing one is dropped.

## Why

A success `exit(0)` at the end of a function:
- **bypasses Rust destructors** (`Drop`), which can skip flushing/cleanup;
- makes the functions **impossible to unit-test** (the test process would exit);
- adds nothing — the function already returns.

Error paths (`exit(1)`) are intentionally **kept**, since they signal failure to the shell.

## Testing

`cargo build` + `cargo test` green (24 tests).