### PR TITLE
🧪 POC: per-instance notes folder via NOT_PATH env override

### DIFF
--- a/src/configurations/mod.rs
+++ b/src/configurations/mod.rs
@@ -1,3 +1,4 @@
 pub mod find;
 pub mod get;
 pub mod models;
+pub mod resolve;

--- a/src/configurations/resolve.rs
+++ b/src/configurations/resolve.rs
@@ -1,0 +1,38 @@
+use std::env;
+
+use crate::configurations::get::get_value_from_config;
+
+/// Resolve the base `not` directory for the current nost instance.
+///
+/// Resolution order (first match wins):
+///   1. `NOT_PATH` environment variable — lets each instance (tests, CI, a
+///      throwaway sandbox, a second checkout…) point at its own notes folder
+///      without touching the shared `config.toml`.
+///   2. `not_path` in `config.toml` — the persistent, per-machine default.
+///
+/// This is the single source of truth for "where do the notes live?", so
+/// test runs never accidentally read or write the production notes folder:
+/// just set `NOT_PATH=/tmp/nost-test` for that instance.
+pub fn resolve_not_path() -> Result<String, Box<dyn std::error::Error>> {
+    if let Ok(path) = env::var("NOT_PATH") {
+        if !path.trim().is_empty() {
+            return Ok(path);
+        }
+    }
+
+    get_value_from_config("not_path")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serial_test::serial;
+
+    #[test]
+    #[serial]
+    fn env_var_takes_precedence() {
+        env::set_var("NOT_PATH", "/tmp/nost-test-instance");
+        assert_eq!(resolve_not_path().unwrap(), "/tmp/nost-test-instance");
+        env::remove_var("NOT_PATH");
+    }
+}

--- a/src/files/create.rs
+++ b/src/files/create.rs
@@ -9,6 +9,7 @@ use chrono::{DateTime, Local, NaiveDate};
 use crate::{
     annotations::annotate::annotate,
     configurations::get::get_value_from_config,
+    configurations::resolve::resolve_not_path,
     dates::get::{get_date_as_text_en, get_date_as_text_fr, get_day_as_string},
     events::{
         models::{Event, EventName},
@@ -25,7 +26,7 @@ use crate::{
 
 pub fn create_file(date: Option<NaiveDate>) -> std::io::Result<String> {
     // handle paths
-    let not_path = get_value_from_config("not_path").unwrap();
+    let not_path = resolve_not_path().unwrap();
 
     let (not_file_path, not_file_name) = match date {
         Some(d) => (build_file_path_for_date(&not_path, d), name_for_date(d)),
@@ -90,7 +91,7 @@ pub fn create_file(date: Option<NaiveDate>) -> std::io::Result<String> {
 
 pub fn create_note_file_with_folders(note_type: String) -> std::io::Result<String> {
     // get the path of the folder to create
-    let not_path = get_value_from_config("not_path").unwrap();
+    let not_path = resolve_not_path().unwrap();
     let today_folder_path = build_folder_path_for_now(&not_path);
 
     log::debug!(

--- a/src/plugins/gdarquie_work/work.rs
+++ b/src/plugins/gdarquie_work/work.rs
@@ -1,7 +1,7 @@
 use crate::annotations::extract::extract_annotations_from_path;
 use crate::annotations::filter::filter_annotation_by_events;
 use crate::annotations::models::Annotation;
-use crate::configurations::get::get_value_from_config;
+use crate::configurations::resolve::resolve_not_path;
 use crate::events::models::EventName;
 use crate::files::build_paths::build_file_path_for_month;
 use chrono::Datelike;
@@ -60,7 +60,7 @@ pub fn compute_work_time_from_annotations(annotations: &Vec<Annotation>) -> i32 
 
 pub fn compute_monthly_work_stats(month: Option<&str>) -> Result<MonthlyWorkStats, std::io::Error> {
     // get all annotations from not path
-    let not_path = get_value_from_config("not_path").unwrap();
+    let not_path = resolve_not_path().unwrap();
 
     // convert month string to chrono::NaiveDate
     let date = match month {

--- a/src/plugins/gdarquie_work/work_annotations/find.rs
+++ b/src/plugins/gdarquie_work/work_annotations/find.rs
@@ -1,12 +1,12 @@
 use crate::annotations::extract::extract_annotations_from_path;
 use crate::annotations::filter::filter_annotation_by_events;
-use crate::configurations::get::get_value_from_config;
+use crate::configurations::resolve::resolve_not_path;
 use crate::events::models::EventName;
 use crate::files::find::find_all_not_files;
 use crate::plugins::gdarquie_work::work_annotations::models::WorkAnnotationWithPath;
 
 pub fn find_last_work_annotation() -> Option<WorkAnnotationWithPath> {
-    let not_path = match get_value_from_config("not_path") {
+    let not_path = match resolve_not_path() {
         Ok(path) => path,
         Err(_) => return None,
     };

--- a/src/projects/initialize.rs
+++ b/src/projects/initialize.rs
@@ -1,12 +1,13 @@
 use serde_json::{json, Value};
-use std::{env, fs::create_dir_all, path::Path};
+use std::{fs::create_dir_all, path::Path};
 
+use crate::configurations::resolve::resolve_not_path;
 use crate::dates::get::get_now_as_string;
 
 pub fn get_project_config_path() -> String {
     // compose configuration path and create configuration folder
-    let not_path = env::var("NOT_PATH").unwrap_or_else(|_| {
-        eprintln!("NOT_PATH environment variable not set.");
+    let not_path = resolve_not_path().unwrap_or_else(|_| {
+        eprintln!("Could not resolve not path (NOT_PATH env or config.toml).");
         std::process::exit(1);
     });
     format!("{}/{}/", not_path, ".nost")
@@ -17,8 +18,8 @@ pub fn get_project_config_path() -> String {
  * in the configuration directory in root/.nost
  */
 pub fn is_project_initialized() -> bool {
-    let not_path = env::var("NOT_PATH").unwrap_or_else(|_| {
-        eprintln!("NOT_PATH environment variable not set.");
+    let not_path = resolve_not_path().unwrap_or_else(|_| {
+        eprintln!("Could not resolve not path (NOT_PATH env or config.toml).");
         std::process::exit(1);
     });
 


### PR DESCRIPTION
## Question explored

> How do we make sure the `not` folder used in **test/dev** is not the one used in **prod**? i.e. how can each nost instance have its own notes folder?

## Finding: two conflicting sources of truth

Today the notes folder is resolved **two different ways**:
- `create.rs`, `work.rs`, `work_annotations/find.rs` read `not_path` from **`config.toml`**;
- `projects/initialize.rs` reads the **`NOT_PATH` env var**.

So there is no single, overridable entry point — and no clean way to point one instance at a throwaway folder.

## POC approach

Introduce a single resolver `configurations::resolve::resolve_not_path()` with a clear precedence:

1. **`NOT_PATH` env var** (if set and non-blank) — lets each instance (tests, CI, a sandbox, a second checkout) target its own notes folder;
2. **`not_path` in `config.toml`** — the persistent per-machine default.

All notes-folder lookups now go through this one function (including `initialize.rs`, which unifies the previously separate env-only path).

## How this answers the question

```sh
# prod: uses config.toml not_path
nost n

# test/dev instance: fully isolated, never touches prod notes
NOT_PATH=/tmp/nost-test nost n
```

Each instance = one env var. Integration tests can set `NOT_PATH` to a temp dir and never risk the real notes.

## Status: proof of concept

- Builds green, **31 tests pass**, 0 clippy warnings.
- Added a focused test proving env precedence.
- **Open design questions** for discussion (not decided here):
  - Should blank/whitespace `NOT_PATH` fall through to config (current behavior) or error?
  - Do we want a `--not-path` CLI flag too, or is env enough?
  - Should `config.toml` `not_path` become optional once `NOT_PATH` exists?

Happy to iterate depending on the direction you prefer.