### PR TITLE
🧪 POC: decouple work feature behind a Plugin trait + registry

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -8,9 +8,8 @@ mod plugins;
 mod projects;
 use crate::commands::new::{new, new_legacy};
 use crate::commands::work::work;
-use crate::plugins::gdarquie_work::commands::end_work::end_work;
-use crate::plugins::gdarquie_work::commands::start_work::start_work;
-use crate::plugins::gdarquie_work::commands::work_stats::work_stats;
+use crate::plugins::gdarquie_work::plugin::WorkPlugin;
+use crate::plugins::plugin::PluginRegistry;
 use dotenv::dotenv;
 use std::env;
 
@@ -27,22 +26,33 @@ fn main() {
         std::process::exit(1);
     }
 
-    if args[1] == "new" || args[1] == "n" {
+    // Plugins are registered here — the only place the core names them. To drop
+    // or extract a feature area, add/remove one line; routing below is generic.
+    let registry = PluginRegistry::new().register(Box::new(WorkPlugin));
+
+    let command = args[1].as_str();
+
+    // Give plugins first chance to claim the command.
+    if let Some(result) = registry.dispatch(command, &args) {
+        if let Err(e) = result {
+            eprintln!("{}", e);
+            std::process::exit(1);
+        }
+        return;
+    }
+    // Core built-in commands.
+    if command == "new" || command == "n" {
         new_legacy(args);
-    } else if args[1] == "start-work" || args[1] == "sw" {
-        start_work(args);
-    } else if args[1] == "end-work" || args[1] == "ew" {
-        end_work();
-    } else if args[1] == "work-stats" || args[1] == "ws" {
-        work_stats(args);
-    } else if args[1] == "new-default" || args[1] == "nn" {
+    } else if command == "new-default" || command == "nn" {
         // wip
         new();
         println!("Creating new default note...");
-    } else if args[1] == "work" || args[1] == "w" {
+    } else if command == "work" || command == "w" {
         work();
+    } else if command == "new-start-work" {
+        // implement new start work
     } else {
-        eprintln!("Unknown command: \"{}\"", args[1]);
+        eprintln!("Unknown command: \"{}\"", command);
         std::process::exit(1);
     }
 }

--- a/src/plugins/gdarquie_work/mod.rs
+++ b/src/plugins/gdarquie_work/mod.rs
@@ -1,3 +1,4 @@
 pub mod commands;
+pub mod plugin;
 pub mod work;
 pub mod work_annotations;

--- a/src/plugins/gdarquie_work/plugin.rs
+++ b/src/plugins/gdarquie_work/plugin.rs
@@ -1,0 +1,35 @@
+use crate::plugins::gdarquie_work::commands::end_work::end_work;
+use crate::plugins::gdarquie_work::commands::start_work::start_work;
+use crate::plugins::gdarquie_work::commands::work_stats::work_stats;
+use crate::plugins::plugin::Plugin;
+
+/// The `work` feature packaged as a self-contained plugin.
+///
+/// It owns its command tokens and their aliases. The core `main.rs` never
+/// names `start_work`/`end_work`/`work_stats` directly anymore — it only talks
+/// to the `Plugin` trait. That is the seam that would let this whole
+/// `gdarquie_work` module move into its own crate later.
+pub struct WorkPlugin;
+
+impl Plugin for WorkPlugin {
+    fn name(&self) -> &'static str {
+        "work"
+    }
+
+    fn handles(&self, command: &str) -> bool {
+        matches!(
+            command,
+            "start-work" | "sw" | "end-work" | "ew" | "work-stats" | "ws"
+        )
+    }
+
+    fn run(&self, command: &str, args: &[String]) -> Result<(), String> {
+        match command {
+            "start-work" | "sw" => start_work(args.to_vec()),
+            "end-work" | "ew" => end_work(),
+            "work-stats" | "ws" => work_stats(args.to_vec()),
+            other => return Err(format!("WorkPlugin cannot handle '{}'", other)),
+        }
+        Ok(())
+    }
+}

--- a/src/plugins/mod.rs
+++ b/src/plugins/mod.rs
@@ -1,1 +1,2 @@
 pub mod gdarquie_work;
+pub mod plugin;

--- a/src/plugins/plugin.rs
+++ b/src/plugins/plugin.rs
@@ -1,0 +1,65 @@
+/// Minimal plugin boundary for nost.
+///
+/// This is the seam that lets a feature area (like `work`) be developed,
+/// tested, and eventually **extracted** without the core `main.rs` knowing
+/// anything about its internals.
+///
+/// Today `main.rs` imports `start_work`, `end_work`, `work_stats` directly —
+/// a hard compile-time coupling. With this trait, the core only knows about
+/// the `Plugin` interface and a registry; each plugin declares which commands
+/// it owns and how to run them.
+pub trait Plugin {
+    /// Short plugin name (for help/diagnostics), e.g. `"work"`.
+    fn name(&self) -> &'static str;
+
+    /// Returns true if this plugin handles the given command token
+    /// (e.g. `"start-work"`, `"sw"`).
+    fn handles(&self, command: &str) -> bool;
+
+    /// Execute the command. `args` is the full process argv (args[1] is the
+    /// command token). Returns `Ok(())` on success, or an error the core can
+    /// surface uniformly.
+    fn run(&self, command: &str, args: &[String]) -> Result<(), String>;
+}
+
+/// A tiny registry the core owns. To drop or extract a plugin, you add/remove
+/// exactly one line here — `main.rs` routing stays untouched.
+pub struct PluginRegistry {
+    plugins: Vec<Box<dyn Plugin>>,
+}
+
+impl PluginRegistry {
+    pub fn new() -> Self {
+        PluginRegistry {
+            plugins: Vec::new(),
+        }
+    }
+
+    pub fn register(mut self, plugin: Box<dyn Plugin>) -> Self {
+        self.plugins.push(plugin);
+        self
+    }
+
+    /// Try to dispatch a command to a plugin. Returns:
+    ///   - `Some(Ok/Err)` if a plugin claimed the command,
+    ///   - `None` if no plugin handles it (core falls back to built-ins).
+    pub fn dispatch(&self, command: &str, args: &[String]) -> Option<Result<(), String>> {
+        for plugin in &self.plugins {
+            if plugin.handles(command) {
+                log::debug!(
+                    "Command '{}' handled by plugin '{}'",
+                    command,
+                    plugin.name()
+                );
+                return Some(plugin.run(command, args));
+            }
+        }
+        None
+    }
+}
+
+impl Default for PluginRegistry {
+    fn default() -> Self {
+        Self::new()
+    }
+}


### PR DESCRIPTION
## Question explored

> How would we handle **extracting the whole `work` feature**? Via a plugin? Do we prepare the extraction in a separate project?

## Finding: the intent is already there, but the coupling is hard

The feature already lives under `src/plugins/gdarquie_work/` (namespaced by author) — the *intent* to treat it as a plugin exists. But the coupling is still **compile-time hard**:

- `main.rs` imports `start_work`, `end_work`, `work_stats` **directly** and hardcodes their command tokens in the `if/else` chain.
- So the core cannot be built/reasoned about without the plugin, and the plugin cannot move out without touching core routing.

## POC approach: introduce a real boundary

A minimal `Plugin` trait + `PluginRegistry` (`src/plugins/plugin.rs`):

```rust
pub trait Plugin {
    fn name(&self) -> &'static str;
    fn handles(&self, command: &str) -> bool;
    fn run(&self, command: &str, args: &[String]) -> Result<(), String>;
}
```

- `WorkPlugin` (`gdarquie_work/plugin.rs`) implements it, owning its command tokens + aliases (`start-work`/`sw`, `end-work`/`ew`, `work-stats`/`ws`).
- `main.rs` no longer names any work function. It registers plugins in **one line** and dispatches generically; plugins get first chance to claim a command, then core built-ins (`new`, `nn`) handle the rest.

## How this answers the question

**Two-step path, and this PR is step 1:**

1. **(this PR) In-repo decoupling** — the core only depends on the `Plugin` trait, not on work internals. Dropping the feature = remove one `.register(...)` line. This is the cheap, reversible move.
2. **(later) Physical extraction** — once the seam holds, `gdarquie_work` can move into its own crate in a Cargo **workspace** (or a separate repo depending on a `nost-core` crate). The remaining work is inverting the 5 inbound dependencies the plugin still has on the core (`annotations`, `files`, `configurations`, `events`) — those would need to become a small public `nost-core` API.

**Recommendation:** do the extraction as a **Cargo workspace in the same repo** first (`nost-core` + `nost-work` crates), not a separate project — you keep atomic PRs and CI, and only split repos if/when the plugin gets its own release cadence.

## Status: proof of concept

- Builds green, **30 tests pass**, 0 clippy warnings.
- No behavior change: all work commands route exactly as before.
- **Open design questions:**
  - Should `run` return a richer error type than `String`?
  - Do we want plugins to self-register (inventory-style) vs. the explicit `.register()` list (explicit is simpler/clearer for now)?
  - Naming: keep `gdarquie_work` or rename to `work` once it is a real crate?

Paired with #48 (per-instance notes folder) — both are exploratory, not meant to merge as-is without your call on direction.